### PR TITLE
Optional exit on error environment configuration

### DIFF
--- a/git-pluck
+++ b/git-pluck
@@ -62,11 +62,20 @@ def main():
             highlight(bcolors.BLUE, 'Entering'),
             highlight(bcolors.ORANGE, os.path.relpath(root))
         )
+        current_repo = os.path.relpath(root)
 
         # Pass the command into each repository
         with pushd(root):
             print highlight(bcolors.WHITE, ' '.join(command))
-            subprocess.call(command, stdout=sys.stdout, stderr=sys.stderr)
+            try:
+                subprocess.check_call(command, stdout=sys.stdout, stderr=sys.stderr)
+            except subprocess.CalledProcessError as e:
+                if os.environ.get('GIT_PLUCK_EXIT_ON_ERROR'):
+                    print "%s '%s'" % (
+                        highlight(bcolors.RED, "Error performing command on repo"),
+                        highlight(bcolors.ORANGE, current_repo)
+                    )
+                    sys.exit(1)
             print
 
 


### PR DESCRIPTION
Check for GIT_PLUCK_EXIT_ON_ERROR environment variable and if it exists, exit if the git command returns a non-zero exit status.
